### PR TITLE
Whitelist all origins for fontawesome fonts and block php requests

### DIFF
--- a/unicorn/templates/default/nginx_unicorn_web_app.erb
+++ b/unicorn/templates/default/nginx_unicorn_web_app.erb
@@ -96,6 +96,17 @@ server {
     add_header Access-Control-Allow-Origin $allow_origin;
     add_header Access-Control-Allow-Methods "GET, HEAD";
   }
+
+  # Allow universal access to fontawesome fonts
+  # TODO: In the future, we want to move these to an opswork config setting
+  location ~ ^/assets/fontawesome.* {
+    add_header Cache-Control "public; max-age=${asset_expires}";
+    add_header ETag "";
+
+    add_header Access-Control-Allow-Origin "*";
+    add_header Access-Control-Allow-Methods "GET, HEAD";
+  }
+
   # [END RIGOR MODIFICATION]
 
   error_page 500 502 503 504 /500.html;

--- a/unicorn/templates/default/nginx_unicorn_web_app.erb
+++ b/unicorn/templates/default/nginx_unicorn_web_app.erb
@@ -39,6 +39,16 @@ server {
     client_max_body_size <%= @application[:nginx][:client_max_body_size] %>;
   <% end %>
 
+  # [RIGOR MODIFICATION]
+  # Instantly reject all PHP requests to prevent bots from ever actually reaching the app
+  # calling internal, redirects them to the rigor-branded 404 page
+  location ~ \.php$ {
+    internal;
+  }
+
+  error_page 404 /404.html
+  # [END RIGOR MODIFICATION]
+
   location / {
     try_files $uri/index.html $uri/index.htm @unicorn;
   }


### PR DESCRIPTION
To properly apply these settings to the servers we need to:

1) Go into CloudFront and check on the Behavior tab of each of the cloudfront instances (staging, prod, beta, etc.) and ensure that we are whitelisting the `Origin` header which allows it to be sent to  nginx.

2) Deploy the changes to nginx via opsworks (TBD on how to do that quickly/easily)

3) Invalidate the old font resources in CloudFront. `/assets/fontawesome*` should do it.